### PR TITLE
#25 Graceful Shutdown and Restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-log",
  "tracing-opentelemetry",
@@ -5247,6 +5248,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/bitpart/Cargo.toml
+++ b/crates/bitpart/Cargo.toml
@@ -44,6 +44,7 @@ subtle = { version = "2.6.1", features = ["const-generics"] }
 tempfile = "3.13.0"
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["full"] }
+tokio-util = { version = "0.7.16", features = ["rt"] }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-opentelemetry = "0.30.0"

--- a/crates/bitpart/src/api.rs
+++ b/crates/bitpart/src/api.rs
@@ -26,6 +26,7 @@ use csml_interpreter::{
 };
 use sea_orm::DatabaseConnection;
 use tokio::sync::oneshot;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use crate::{
     channels::signal,
@@ -38,6 +39,8 @@ use crate::{
 pub struct ApiState {
     pub db: DatabaseConnection,
     pub auth: String,
+    pub token: CancellationToken,
+    pub tracker: TaskTracker,
     pub attachments_dir: PathBuf,
     pub manager: Box<signal::SignalManager>,
 }
@@ -405,6 +408,8 @@ pub async fn link_channel(
     let msg = signal::ChannelMessage {
         msg: contents,
         db: state.db.clone(),
+        token: state.token.clone(),
+        tracker: state.tracker.clone(),
         sender: send,
     };
     state.manager.send(msg);
@@ -420,6 +425,8 @@ pub async fn start_channel(channel_id: &str, state: &ApiState) -> Result<String>
     let msg = signal::ChannelMessage {
         msg: contents,
         db: state.db.clone(),
+        token: state.token.clone(),
+        tracker: state.tracker.clone(),
         sender: send,
     };
     state.manager.send(msg);

--- a/crates/bitpart/src/api.rs
+++ b/crates/bitpart/src/api.rs
@@ -94,7 +94,7 @@ pub async fn read_bot(id: &str, state: &ApiState) -> Result<Option<BotVersion>> 
 pub async fn delete_bot(id: &str, state: &ApiState) -> Result<()> {
     db::bot::delete_by_bot_id(id, &state.db).await?;
     db::memory::delete_by_bot_id(id, &state.db).await?;
-    let channels = db::channel::get_by_bot_id(&id, &state.db).await?;
+    let channels = db::channel::get_by_bot_id(id, &state.db).await?;
     for channel in channels.iter() {
         delete_channel(&channel.channel_id, id, state).await?;
     }

--- a/crates/bitpart/src/channels/signal.rs
+++ b/crates/bitpart/src/channels/signal.rs
@@ -655,7 +655,7 @@ async fn receive<S: Store>(
             }
             Err(err) => {
                 error!("Failed to receive messages: {:?}", err);
-                sleep(Duration::from_millis(5000)).await;
+                sleep(Duration::from_secs(60)).await;
             }
         }
     }

--- a/crates/bitpart/src/db/channel.rs
+++ b/crates/bitpart/src/db/channel.rs
@@ -75,6 +75,15 @@ pub async fn get_by_id(id: &str, db: &DatabaseConnection) -> Result<Option<chann
     Ok(entries)
 }
 
+pub async fn get_by_bot_id(bot_id: &str, db: &DatabaseConnection) -> Result<Vec<channel::Model>> {
+    let entries = Channel::find()
+        .filter(channel::Column::BotId.eq(bot_id.to_owned()))
+        .all(db)
+        .await?;
+
+    Ok(entries)
+}
+
 pub async fn delete(channel_id: &str, bot_id: &str, db: &DatabaseConnection) -> Result<()> {
     let entry = Channel::find()
         .filter(channel::Column::BotId.eq(bot_id.to_owned()))

--- a/crates/bitpart/src/socket.rs
+++ b/crates/bitpart/src/socket.rs
@@ -38,10 +38,10 @@ pub async fn handler(
     ws.on_upgrade(move |socket| handle_socket(socket, addr, state))
 }
 
-async fn handle_socket(mut socket: WebSocket, who: SocketAddr, state: ApiState) {
+async fn handle_socket(mut socket: WebSocket, who: SocketAddr, mut state: ApiState) {
     while let Some(msg) = socket.recv().await {
         let msg = if let Ok(msg) = msg {
-            match process_message(msg, who, &state).await {
+            match process_message(msg, who, &mut state).await {
                 Ok(Some(msg)) => msg,
                 Ok(None) => {
                     debug!("Websocket closed");
@@ -87,7 +87,7 @@ fn wrap_response<S: Serialize>(response_type: &str, res: &S) -> Result<Option<Me
 async fn process_message(
     msg: Message,
     who: SocketAddr,
-    state: &ApiState,
+    state: &mut ApiState,
 ) -> Result<Option<Message>> {
     match msg {
         Message::Text(t) => {


### PR DESCRIPTION
fixes #25 

This PR adds a number of changes to process lifecycle behavior. 

1. Add a bot, link it, and then unlink it from the primary Signal client. You should see it attempting to reconnect every 60 seconds.
2. Add a bot, link it, and send it a message to make sure it's working. Delete the bot, send it a message again, and ensure you do **not** get a response.