### PR TITLE
Make delete commands return errors if channel/bot is not found.

### DIFF
--- a/crates/bitpart-cli/src/main.rs
+++ b/crates/bitpart-cli/src/main.rs
@@ -534,7 +534,7 @@ async fn main() -> Result<()> {
                             }
                         },
                         SocketMessage::Error(res) => {
-                            println!("{}", res.response.to_string());
+                            println!("{}", res.response);
                         }
                         _ => {
                             println!("Wrong socket message type")

--- a/crates/bitpart-cli/src/main.rs
+++ b/crates/bitpart-cli/src/main.rs
@@ -533,6 +533,9 @@ async fn main() -> Result<()> {
                                 error!("Unrecognized message response: {:?}", res.response);
                             }
                         },
+                        SocketMessage::Error(res) => {
+                            println!("{}", res.response.to_string());
+                        }
                         _ => {
                             println!("Wrong socket message type")
                         }

--- a/crates/bitpart/src/db/channel.rs
+++ b/crates/bitpart/src/db/channel.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use bitpart_common::error::Result;
+use bitpart_common::error::{BitpartErrorKind, Result};
 use sea_orm::*;
 use uuid;
 
@@ -84,9 +84,10 @@ pub async fn delete(channel_id: &str, bot_id: &str, db: &DatabaseConnection) -> 
 
     if let Some(e) = entry {
         e.delete(db).await?;
+        Ok(())
+    } else {
+        Err(BitpartErrorKind::Db(DbErr::RecordNotFound(bot_id.to_owned())).into())
     }
-
-    Ok(())
 }
 
 pub async fn delete_by_bot_id(bot_id: &str, db: &DatabaseConnection) -> Result<()> {


### PR DESCRIPTION
To test:

1. Try deleting a bot with the cli that does not exist, it should print an error message.
2. Try deleting a channel with the cli that does not exist, it should print an error message.
3. Try deleting a bot with the cli that **does** exist, it should **not** print an error message.
4. Try deleting a channel with the cli that **does** exist, it should **not** print an error message.